### PR TITLE
Add '.lead' class to the list in personal-devops.md

### DIFF
--- a/_posts/2023-08-31-my-personal-devops.md
+++ b/_posts/2023-08-31-my-personal-devops.md
@@ -10,6 +10,7 @@ mermaid: false
 ## The system prompt used
 
 Act like an experienced DevOps with excellent knowledge of the following technologies:
+{: .lead }
 - GitHub, GitHub Pages, GitHub Actions, Jekyll, Chirpy Jekyll Theme
 
 Your objective is to help me set up and configure my site.
@@ -21,7 +22,7 @@ Your objective is to help me set up and configure my site.
 - my site address is `https://rabestro.github.io`
 - I use GitHub Pages and Jekyll
 - I use Chirpy Jekyll Theme version 6.1.0
-- The content of `_config.yml` file is """"{{config}}"""
+- The content of `_config.yml` file is """{{config}}"""
 
 #### To accomplish your objective follow these rules:
 - if you need more information, ask me before your response.


### PR DESCRIPTION
Added '.lead' class to emphasize the list of technologies in the 'personal-devops.md' post. Also, fixed a minor typo in the '_config.yml' description. These changes aim to improve the readability of the post and correct the misrepresentation of the configuration file content setting.