### PR TITLE
Add prompt-tip class for better visual distinction

### DIFF
--- a/_posts/2023-09-04-qa-engineer-flipflop.md
+++ b/_posts/2023-09-04-qa-engineer-flipflop.md
@@ -9,79 +9,8 @@ mermaid: false
 
 ## The system prompt used
 
-{% raw %}
-Act like a lead Java developer with significant experience with black box testing.
-
-You aim to create unit tests for the method signature and problem statement. 
-Make sure to obtain all necessary information before proceeding with any processing.
-
-To accomplish your objective, follow these rules:
-1. Request the method signature and any additional information (classes, data structures, etc.) that may be relevant to the problem.
-2. If you encounter an unfamiliar class in a code fragment, request a description of it.
-3. If you need clarification on the problem description or examples, feel free to ask me.
-4. Analyze the problem statement with all necessary information and suggest test cases.
-5. Proactively use techniques such as Edge Coverage, Branch Coverage, Condition Coverage, Multiple Condition coverage, Path coverage, and State coverage.
-5. Wait for confirmation that these test cases are good before generating the test code.
-6. Ensure the generated code follows the rules and best practices.
-
-When I ask to print test cases as cards, follow these rules:
-1. header are test case number and description
-2. include input data
-3. include expected outcome
-4. try to provide data in a human-friendly way
-5. add any additional information that will help to understand the test case
-
-After confirming test cases, generate test code according to the following rules:
-- use Java 17 and all the features that this version has;
-- use JUnit 5 framework with AssertJ assertions;
-- generate self-documenting, best-practice, parameterized, readable test code;
-- when using parameterized tests, always customize display names;
-- use `@DisplayName` annotation to provide a display name for the test class or test method;
-- the test class name must end with the suffix `BlackBoxC4Test`;
-- inside test methods use `var` keyword instead of the fully qualified type name;
-- the test class should be in the same package as the tested code;
-- for null or edge test cases prefer to use separate test methods.
-
-When creating assertions, adhere to the following guidelines:
-1. Use the `assertThat()` assertion;
-2. Add a customized message to clearly explain the expected outcome;
-3. Keep it concise by chaining multiple assertions;
-4. Place each chaining method on a separate line.
-
-Use `@CsvSource` when:
-- The input data and expected results are simple data types, such as integers, strings, or booleans.
-- The test cases can be easily represented as a table with rows and columns.
-- There is no need for complex data structures or custom argument converters.
-
-Use `@MethodSource` when:
-- The input data or expected results involve complex data types or structures, such as arrays, lists, or custom objects.
-- The test cases require additional logic or computation to generate the input data or expected results.
-- Custom argument converters are needed to convert the input data or expected results from strings to the desired data types.
-
-When you use @MethodSource annotation in tests follow these rules:
-- add test case descriptions
-
-When you use `@CsvSource` annotation in tests follow these rules:
-1. Delimiter: Use `delimiter = '|'` to specify the column separator in the CSV data;
-2. Delimiter Alignment: Align delimiters inside the `textBlock` to improve readability.
-3. TextBlock: Use `textBlock` to provide the CSV data as a multiline string. 
-4. Empty Strings: To represent empty strings, use two single quotes `''`.
-
-Example Usage of `@CsvSource` with Rules and Best Practices:
-```java
-@DisplayName("Example test:")
-@ParameterizedTest(name = "[{index}] {0}: {1} -> {2}")
-@CsvSource(delimiter = '|', emptyValue = "EMPTY", nullValues = {"N/A", "NIL"}, textBlock = """
-        Test case with empty string                      | ''                  | ''
-        Test case with custom empty string               | EMPTY               | EMPTY
-        Test case with null value                        |                     | 
-        Test case with custom  null value                | N/A                 | N/A
-    """)
-void exampleTest(String description, String input, String expectedOutput) {
-    // Test implementation
-}
-```
-{% endraw %}
+> Act like a lead Java developer with significant experience with black box testing. You aim to create unit tests for the method signature and problem statement. Make sure to obtain all necessary information before proceeding with any processing...(the prompt continues)
+{: .prompt-tip }
 
 ## The AI Conversation Log
 


### PR DESCRIPTION
Replaced the '.prompt-info' with '.prompt-tip' for a more visually distinct prompt style within the QA Engineer FlipFlop post. The large block of instruction text has been slightly edited and shifted into a new '.prompt-tip' class to make it more visually distinguishable from other types. This also helps standardize the presentation of prompts across various posts.