### PR TITLE
Add admin config.yml for git-gateway

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -1,0 +1,19 @@
+backend:
+  name: git-gateway
+  branch: main # Branch to update (optional; defaults to master)
+
+media_folder: "assets/img/uploads" # Media files will be stored in the repo under this folder
+public_folder: "/assets/img/uploads" # The src attribute for uploaded media will begin with this folder
+
+collections:
+  - name: "post"
+    label: "Post"
+    folder: "_posts"
+    create: true
+    slug: "{{year}}-{{month}}-{{day}}-{{slug}}"
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Publish Date", name: "date", widget: "datetime"}
+      - {label: "Categories", name: "categories", widget: "list"}
+      - {label: "Tags", name: "tags", widget: "list"}
+      - {label: "Body", name: "body", widget: "markdown"}

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+</head>
+<body>
+<!-- Include the script that builds the page and powers Netlify CMS -->
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Added 'admin/config.yml' for use with git-gateway. This new configuration will enable content management through Netlify CMS, setting repository's default branch as main. It sets up the '_posts' directory for post creation, and establishes the standardized slug format. The fields to be included in the post - such as title, publish date, categories, tags and body - have been defined. Media file pathway for any uploaded content is also specified.