### PR TITLE
Fix pre-commit installation on Windows ARM64

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 ruby = "3.3"
 "pipx:pre-commit" = "latest"
-python = "3.13"
+python = "3.14"
 uv = "latest"
 
 [tasks.setup]

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,8 @@
 [tools]
 ruby = "3.3"
-pre-commit = "latest"
+"pipx:pre-commit" = "latest"
+python = "3.14"
+uv = "latest"
 
 [tasks.setup]
 description = "Setup all project dependencies"

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 ruby = "3.3"
 "pipx:pre-commit" = "latest"
-python = "3.14"
+python = "3.13"
 uv = "latest"
 
 [tasks.setup]


### PR DESCRIPTION
Fixes #66. Switched pre-commit to use pipx backend to support Windows ARM64.