### PR TITLE
chore: remove dead reviewers: option from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: "/"
     assignees:
       - "rabestro"
-    reviewers:
-      - "rabestro"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -20,8 +18,6 @@ updates:
     directory: "/"
     assignees:
       - "rabestro"
-    reviewers:
-      - "rabestro"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -35,8 +31,6 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     assignees:
-      - "rabestro"
-    reviewers:
       - "rabestro"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## Summary

- Removes the `reviewers:` block from all three ecosystem entries (`github-actions`, `bundler`, `pre-commit`) in `.github/dependabot.yml`.
- GitHub retired the `reviewers` configuration option for Dependabot, superseded by `CODEOWNERS`:
  - [Announcement (2025-04-29)](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)
  - [Effective (2025-08-08)](https://github.blog/changelog/2025-08-08-dependabot-reviewers-configuration-option-is-replaced-by-code-owners/)
- Since the announcement, GitHub has silently ignored these blocks — no error, no warning, just dead config.
- `assignees:` is a separate, unaffected option and is left untouched.

## Test plan

- [x] Ran a script to strip only `reviewers:` keys and their list items, leaving everything else in the file untouched.
- [x] Validated the resulting YAML parses: `ruby -ryaml -e "YAML.load_file('.github/dependabot.yml')"` → OK.
- [x] Diffed the change to confirm only the three `reviewers:` blocks (6 lines total) were removed — schedules, labels, `commit-message` prefixes, and `assignees:` are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)